### PR TITLE
Fix version number logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ SRC_DIRS       = $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*.go \
                    -exec dirname {} \\; | sort | uniq")
 TEST_DIRS     ?= $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go \
                    -exec dirname {} \\; | sort | uniq")
-VERSION       ?= $(shell git describe --always --abbrev=7 --dirty)
+VERSION       ?= $(shell git describe --always --tags --abbrev=7 --dirty)
 ifeq ($(shell uname -s),Darwin)
 STAT           = stat -f '%c %N'
 else
@@ -47,7 +47,7 @@ PLATFORM?=linux
 ARCH?=amd64
 
 GO_BUILD       = env CGO_ENABLED=0 GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -i $(GOFLAGS) \
-                   -ldflags "-X $(KCP_PKG)/pkg.VERSION=$(VERSION)"
+                   -ldflags "-X main.version=$(VERSION)"
 BASE_PATH      = $(ROOT:/src/github.com/munnerz/keepalived-cloud-provider/=)
 export GOPATH  = $(BASE_PATH):$(ROOT)/vendor
 
@@ -104,7 +104,7 @@ verify: .init
 	@# Exclude the generated (zz) files for now, as well as defaults.go (it
 	@# observes conventions from upstream that will not pass lint checks).
 	@$(DOCKER_CMD) sh -c \
-	  'for i in $$(find $(TOP_SRC_DIRS) -name *.go); \
+	  'for i in $$(find $(TOP_SRC_DIRS) -name \\*.go); \
 	  do \
 	   golint --set_exit_status $$i || exit 1; \
 	  done'

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
 	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
-	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/munnerz/keepalived-cloud-provider/keepalivedcp"
 )
@@ -30,18 +29,20 @@ func init() {
 func main() {
 	s := options.NewCloudControllerManagerServer()
 	s.AddFlags(pflag.CommandLine)
+	addVersionFlag()
 
 	flag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	verflag.PrintAndExitIfRequested()
+	printAndExitIfRequested()
 
 	cloud, err := cloudprovider.InitCloudProvider(keepalivedcp.ProviderName, s.CloudConfigFile)
 	if err != nil {
 		glog.Fatalf("Cloud provider could not be initialized: %v", err)
 	}
 
+	glog.Info("Starting version ", version)
 	if err := app.Run(s, cloud); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/munnerz/keepalived-cloud-provider/keepalivedcp"
+	"github.com/spf13/pflag"
+)
+
+var (
+	version     string = "unknwon"
+	versionFlag bool
+)
+
+func addVersionFlag() {
+	pflag.BoolVar(&versionFlag, "version", false, "Print version information and quit")
+}
+
+func printAndExitIfRequested() {
+	if versionFlag {
+		fmt.Printf("%s %s\n", keepalivedcp.ProviderName, version)
+		os.Exit(0)
+	}
+}


### PR DESCRIPTION
Previously this was using the build in Kubernetes style version
handling.  That meant that the version number was always wrong and that
it claimed to be Kubernetes when it printed the version number.  In
addition, it's hard to change this since the program name is hard coded
in the logic to print out the version number.

To fix those issues and allow logging the version number when start,
this patch changes the version handling logic to work internally.

This also patches the Makefile to properly escape the *.go pattern in
the verify target so that it isn't expanded early.